### PR TITLE
docs: add docs for 3rd party module cz-github-jira-conventional

### DIFF
--- a/docs/third-party-commitizen.md
+++ b/docs/third-party-commitizen.md
@@ -11,6 +11,17 @@ meaningful way.
 
 It can be installed with `pip install conventional-JIRA`.
 
+### [GitHub JIRA Conventional](https://pypi.org/project/cz-github-jira-conventional/)
+
+This plugin extends the commitizen tools by:
+- requiring a JIRA issue id in the commit message
+- creating links to GitHub commits in the CHANGELOG.md
+- creating links to JIRA issues in the CHANGELOG.md
+
+It can be installed with `cz-github-jira-conventional`.
+
+For installation instructions (configuration and pre-commit) please visit https://github.com/apheris/cz-github-jira-conventional
+
 ### [Commitizen emoji](https://pypi.org/project/commitizen-emoji/)
 
 Just like *conventional commit* format, but with emojis and optionally time spent and related tasks.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Add documentation for the 3rd party module https://github.com/apheris/cz-github-jira-conventional


## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
This addon extends the commitizen tools by:
- **require a Jira issue id** in the commit message
- **create links to GitHub** commits in the CHANGELOG.md
- **create links to Jira** issues in the CHANGELOG.md